### PR TITLE
简称已经不支持

### DIFF
--- a/Chapter04/qt_QDialogButtonBox.py
+++ b/Chapter04/qt_QDialogButtonBox.py
@@ -41,9 +41,9 @@ class DialogButtonBox(QWidget):
         buttonBox.setStandardButtons(
             QDialogButtonBox.Cancel | QDialogButtonBox.Ok | QDialogButtonBox.Reset | QDialogButtonBox.Help | QDialogButtonBox.Yes | QDialogButtonBox.No | QDialogButtonBox.Apply)
         # 自定义按钮
-        buttonBox.addButton(QPushButton('MyOk-ApplyRole'), buttonBox.ApplyRole)
-        buttonBox.addButton(QPushButton('MyOk-AcceptRole'), buttonBox.AcceptRole)
-        buttonBox.addButton(QPushButton('MyNo-AcceptRole'), buttonBox.RejectRole)
+        buttonBox.addButton(QPushButton('MyOk-ApplyRole'), buttonBox.ButtonRole.ApplyRole)
+        buttonBox.addButton(QPushButton('MyOk-AcceptRole'), buttonBox.ButtonRole.AcceptRole)
+        buttonBox.addButton(QPushButton('MyNo-AcceptRole'), buttonBox.ButtonRole.RejectRole)
         # 绑定信号与槽
         buttonBox.accepted.connect(lambda: self.label.setText(self.label.text() + '\n触发了accepted'))
         buttonBox.rejected.connect(lambda: self.label.setText(self.label.text() + '\n触发了rejected'))


### PR DESCRIPTION
Chapter04/qt_QDialogButtonBox.py文件中
第44-46行
类似buttonBox.ApplyRole 简称已经不支持！
已经在Windows 10 工作站版和Linux-Gnome48 的如下环境验证：
Python3.13，pip25.2,PySide6 6.9.1
